### PR TITLE
Feat/wallet connection

### DIFF
--- a/src/components/layout/sidebar/app-sidebar.tsx
+++ b/src/components/layout/sidebar/app-sidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type * as React from "react";
+import { useSidebar } from "@/components/ui/sidebar";
 import {
   AudioWaveform,
   BookOpen,
@@ -13,6 +14,8 @@ import {
   PieChart,
   Settings2,
   SquareTerminal,
+  AlertTriangle,
+  Wallet as WalletIcon,
 } from "lucide-react";
 
 import {
@@ -166,6 +169,8 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 
     const { handleConnect, handleDisconnect, account } = useWallet();
     const isConnected = Boolean(account);
+
+    const { open } = useSidebar();
   
   return (
     <Sidebar collapsible="icon" {...props}>
@@ -173,11 +178,17 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <TeamSwitcher teams={data.teams} />
       </SidebarHeader>
       <SidebarContent>
-        {!isConnected && (
-          <div className="bg-yellow-100 dark:bg-yellow-900 text-yellow-900 dark:text-yellow-100 rounded-md p-2 mb-2 text-sm">
-            Connect your wallet to enable on-chain actions
-          </div>
-        )}
+      {!isConnected && (
+         open ? (
+           <div className="bg-yellow-100 dark:bg-yellow-900 text-yellow-900 dark:text-yellow-100 rounded-md p-2 mb-2 text-sm">
+             Connect your wallet to enable on-chain actions
+           </div>
+         ) : (
+           <div className="flex items-center justify-center p-2 mb-2">
+             <AlertTriangle className="h-6 w-6 text-yellow-500 dark:text-yellow-400" />
+           </div>
+         )
+       )}
 
         <NavMain items={data.navMain} />
         <NavProjects projects={data.projects} />
@@ -185,14 +196,15 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       <SidebarFooter>
          <div className="flex flex-col gap-2 px-4 py-2">
             <Button
-              variant="outline"
-              size="default"
-              onClick={isConnected ? handleDisconnect : handleConnect}
-            >
-              {isConnected ? "Disconnect Wallet" : "Connect Wallet"}
-            </Button>
-
-            {/* El resto del footer */}
+           variant="outline"
+           size="default"
+           onClick={isConnected ? handleDisconnect : handleConnect}
+         >
+           {open
+             ? (isConnected ? "Disconnect Wallet" : "Connect Wallet")
+             : <WalletIcon className="h-5 w-5" />
+           }
+         </Button>
             <div className="flex items-center justify-between">
               <p className="text-sm font-medium">Theme</p>
               <ThemeToggle />

--- a/src/components/layout/sidebar/app-sidebar.tsx
+++ b/src/components/layout/sidebar/app-sidebar.tsx
@@ -29,6 +29,9 @@ import { NavUser } from "./nav-user";
 import { ThemeToggle } from "@/components/layout/sidebar/theme-toggler";
 import { Separator } from "@/components/ui/separator";
 
+import { useWallet } from "@/components/wallet/hooks/wallet.hook";            
+import { Button } from "@/components/ui/button";          
+
 // This is sample data.
 const data = {
   user: {
@@ -160,23 +163,45 @@ const data = {
 };
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+
+    const { handleConnect, handleDisconnect, account } = useWallet();
+    const isConnected = Boolean(account);
+  
   return (
     <Sidebar collapsible="icon" {...props}>
       <SidebarHeader>
         <TeamSwitcher teams={data.teams} />
       </SidebarHeader>
       <SidebarContent>
+        {!isConnected && (
+          <div className="bg-yellow-100 dark:bg-yellow-900 text-yellow-900 dark:text-yellow-100 rounded-md p-2 mb-2 text-sm">
+            Connect your wallet to enable on-chain actions
+          </div>
+        )}
+
         <NavMain items={data.navMain} />
         <NavProjects projects={data.projects} />
       </SidebarContent>
       <SidebarFooter>
-        <div className="flex items-center justify-between px-4 py-2">
-          <p className="text-sm font-medium">Theme</p>
-          <ThemeToggle />
-        </div>
-        <Separator className="my-1" />
-        <NavUser user={data.user} />
-      </SidebarFooter>
+         <div className="flex flex-col gap-2 px-4 py-2">
+            <Button
+              variant="outline"
+              size="default"
+              onClick={isConnected ? handleDisconnect : handleConnect}
+            >
+              {isConnected ? "Disconnect Wallet" : "Connect Wallet"}
+            </Button>
+
+            {/* El resto del footer */}
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium">Theme</p>
+              <ThemeToggle />
+            </div>
+            <Separator className="my-1" />
+            <NavUser user={data.user} />
+          </div>
+          <SidebarRail />
+        </SidebarFooter>
       <SidebarRail />
     </Sidebar>
   );

--- a/src/components/wallet/hooks/wallet.hook.ts
+++ b/src/components/wallet/hooks/wallet.hook.ts
@@ -3,7 +3,7 @@ import { useGlobalAuthenticationStore } from "../store/store";
 import { kit } from "@/lib/wallet-kit";
 
 export const useWallet = () => {
-  const { connectWalletStore, disconnectWalletStore } =
+  const { connectWalletStore, disconnectWalletStore, address } =
     useGlobalAuthenticationStore();
 
   const connectWallet = async () => {
@@ -11,11 +11,8 @@ export const useWallet = () => {
       modalTitle: "Connect to your favorite wallet",
       onWalletSelected: async (option: ISupportedWallet) => {
         kit.setWallet(option.id);
-
-        const { address } = await kit.getAddress();
-        const { name } = option;
-
-        connectWalletStore(address, name);
+        const { address: addr } = await kit.getAddress();
+        connectWalletStore(addr, option.name);
       },
     });
   };
@@ -35,18 +32,15 @@ export const useWallet = () => {
 
   const handleDisconnect = async () => {
     try {
-      if (disconnectWallet) {
-        await disconnectWallet();
-      }
+      await disconnectWallet();
     } catch (error) {
       console.error("Error disconnecting wallet:", error);
     }
   };
 
   return {
-    connectWallet,
-    disconnectWallet,
     handleConnect,
     handleDisconnect,
+    account: address, 
   };
 };


### PR DESCRIPTION
<p align="center"> <img src="https://github.com/user-attachments/assets/25cfd5b8-e303-4af6-920e-e42d1ac8d418" alt="CLR-S (2)"> </p>

# Pull Request | GrantChain

## 1. Issue Link

<!-- Provide the link to the related issue here -->

- Closes #6 

---

## 2. Brief Description of the Issue

The sidebar did not surface the wallet connection status or afford a way to connect/disconnect directly. Users who weren’t connected saw no prompt or button, and collapsing the sidebar hid any feedback entirely. This issue adds a Connect/Disconnect Wallet button in the sidebar, injects a clear warning banner (or icon when collapsed) for unconnected users, and ensures the UI dynamically reflects connection state in both expanded and collapsed modes.

---

## 3. Type of Change

Mark with an `x` all the checkboxes that apply (like `[x]`).

- [ ] 📝 Documentation (updates to README, docs, or comments)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 👌 Enhancement (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

---

## 4. Changes Made

- Sidebar collapse detection: Integrated the useSidebar hook to expose an open boolean, so we know when the sidebar is expanded vs. collapsed.
- Adaptive warning display: Refactored the wallet warning section to render a full-text banner (Connect your wallet…) when expanded, and switch to a lone AlertTriangle icon when collapsed.
- Responsive Connect button: Updated the Connect/Disconnect Wallet button so it shows the full “Connect Wallet” / “Disconnect Wallet” label in expanded mode, and renders only a WalletIcon when the sidebar is collapsed.

---

## 5. Evidence

https://github.com/user-attachments/assets/629e9df5-4fe5-46dc-b7b0-c2f133637092



# If you don't use this template, you'd be ignored
