### PR TITLE
feat: add notification button

### DIFF
--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -1,11 +1,12 @@
 "use client";
 
+import { NotificationButton } from "@/components/notifications/NotificationButton";
 import { Button } from "@/components/ui/button";
-import { ThemeToggle } from "../sidebar/theme-toggler";
 import { useWallet } from "@/components/wallet/hooks/useWallet";
-import { Wallet as WalletIcon } from "lucide-react";
 import useLayoutDashboard from "@/hooks/useLayoutDashboard";
+import { Wallet as WalletIcon } from "lucide-react";
 import { MobileTrigger } from "../sidebar/mobile-trigger";
+import { ThemeToggle } from "../sidebar/theme-toggler";
 
 export const Header = () => {
   const { handleConnect, handleDisconnect, account } = useWallet();
@@ -24,6 +25,7 @@ export const Header = () => {
         )}
 
         <div className="flex items-center gap-4">
+          <NotificationButton />
           <ThemeToggle />
           <Button
             variant="outline"

--- a/src/components/notifications/NotificationButton.tsx
+++ b/src/components/notifications/NotificationButton.tsx
@@ -1,0 +1,205 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Separator } from "@/components/ui/separator";
+import {
+  type Notification,
+  mockNotifications,
+} from "@/interfaces/Notification";
+import { AnimatePresence, motion } from "framer-motion";
+import { AlertTriangle, Bell, CheckCircle, Info, XCircle } from "lucide-react";
+import { useState } from "react";
+
+const typeIconMap = {
+  info: (
+    <Info
+      className="h-5 w-5 text-blue-500 dark:text-blue-400"
+      aria-label="Info"
+    />
+  ),
+  success: (
+    <CheckCircle
+      className="h-5 w-5 text-green-500 dark:text-green-400"
+      aria-label="Éxito"
+    />
+  ),
+  warning: (
+    <AlertTriangle
+      className="h-5 w-5 text-yellow-500 dark:text-yellow-400"
+      aria-label="Advertencia"
+    />
+  ),
+  error: (
+    <XCircle
+      className="h-5 w-5 text-red-500 dark:text-red-400"
+      aria-label="Error"
+    />
+  ),
+};
+
+const CLEAR_ANIMATION_DELAY = 800;
+const RESTORE_NOTIFICATIONS_DELAY = 1200;
+
+export const NotificationButton = () => {
+  const [notifications, setNotifications] =
+    useState<Notification[]>(mockNotifications);
+  const [selected, setSelected] = useState<Notification | null>(null);
+  const [cleared, setCleared] = useState(false);
+  const [cooldown, setCooldown] = useState(false);
+
+  const unreadCount = notifications.filter((n) => !n.read).length;
+
+  const handleSelectNotification = (notification: Notification) => {
+    setSelected(notification);
+    setNotifications((prev) =>
+      prev.map((n) => (n.id === notification.id ? { ...n, read: true } : n)),
+    );
+  };
+
+  const handleBack = () => setSelected(null);
+
+  const handleClearAll = () => {
+    setCleared(true);
+    setCooldown(true);
+    setTimeout(() => {
+      setNotifications([]);
+      setTimeout(() => {
+        setNotifications(mockNotifications);
+        setCleared(false);
+        setCooldown(false);
+      }, RESTORE_NOTIFICATIONS_DELAY);
+    }, CLEAR_ANIMATION_DELAY);
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Abrir notificaciones"
+          className="relative"
+        >
+          <Bell className="h-6 w-6" />
+          {unreadCount > 0 && (
+            <Badge className="absolute -top-1 -right-1 px-1.5 py-0.5 text-xs bg-red-500 text-white dark:bg-red-400 dark:text-black rounded-full">
+              {unreadCount}
+            </Badge>
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-80 p-0">
+        <AnimatePresence mode="wait">
+          {cleared ? (
+            <motion.div
+              key="cleared"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              className="flex flex-col items-center justify-center p-6"
+            >
+              <span className="text-lg font-semibold">
+                ¡Notificaciones limpiadas!
+              </span>
+              <span className="text-sm text-muted-foreground mt-2">
+                Se restaurarán en breve...
+              </span>
+            </motion.div>
+          ) : selected ? (
+            <motion.div
+              key="detail"
+              initial={{ opacity: 0, x: 40 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -40 }}
+              className="p-4"
+            >
+              <div className="flex items-center gap-2 mb-2">
+                {typeIconMap[selected.type]}
+                <span className="font-semibold text-base">
+                  {selected.title}
+                </span>
+              </div>
+              <p className="text-sm text-muted-foreground mb-4">
+                {selected.description}
+              </p>
+              <span className="text-xs text-gray-400 dark:text-gray-500">
+                {new Date(selected.date).toLocaleString()}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-4 w-full"
+                onClick={handleBack}
+              >
+                Volver
+              </Button>
+            </motion.div>
+          ) : (
+            <motion.div
+              key="list"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              className="max-h-96 overflow-y-auto"
+            >
+              <div className="flex items-center justify-between px-4 py-2">
+                <span className="font-semibold text-lg">Notificaciones</span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleClearAll}
+                  disabled={cooldown}
+                  className="text-xs text-red-500 hover:bg-red-100 dark:hover:bg-red-900"
+                >
+                  Limpiar todo
+                </Button>
+              </div>
+              <Separator />
+              {notifications.length === 0 ? (
+                <div className="p-4 text-center text-muted-foreground">
+                  No hay notificaciones.
+                </div>
+              ) : (
+                <ul className="divide-y divide-muted">
+                  {notifications.map((notification) => (
+                    <li
+                      key={notification.id}
+                      className={`flex items-start gap-3 px-4 py-3 cursor-pointer transition-colors ${notification.read ? "bg-muted" : "bg-background hover:bg-accent"}`}
+                      aria-label={notification.title}
+                      onClick={() => handleSelectNotification(notification)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") handleSelectNotification(notification);
+                      }}
+                    >
+                      {typeIconMap[notification.type]}
+                      <div className="flex-1">
+                        <span
+                          className={`block font-medium ${notification.read ? "text-muted-foreground" : "text-foreground"}`}
+                        >
+                          {notification.title}
+                        </span>
+                        <span className="block text-xs text-muted-foreground">
+                          {notification.description}
+                        </span>
+                        <span className="block text-[10px] text-gray-400 dark:text-gray-500 mt-1">
+                          {new Date(notification.date).toLocaleString()}
+                        </span>
+                      </div>
+                      {!notification.read && (
+                        <span className="ml-2 mt-1 w-2 h-2 rounded-full bg-blue-500 dark:bg-blue-400" />
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/src/interfaces/Notification.ts
+++ b/src/interfaces/Notification.ts
@@ -1,0 +1,43 @@
+export interface Notification {
+  id: string;
+  title: string;
+  description: string;
+  type: "info" | "success" | "warning" | "error";
+  read: boolean;
+  date: string;
+}
+
+export const mockNotifications: Notification[] = [
+  {
+    id: "1",
+    title: "Bienvenido a GrantFox",
+    description: "Gracias por unirte a nuestra plataforma.",
+    type: "success",
+    read: false,
+    date: "2024-07-01T10:00:00Z",
+  },
+  {
+    id: "2",
+    title: "Nuevo pago recibido",
+    description: "Has recibido un nuevo pago en tu cuenta.",
+    type: "info",
+    read: false,
+    date: "2024-07-02T12:30:00Z",
+  },
+  {
+    id: "3",
+    title: "Actualización de seguridad",
+    description: "Por favor, actualiza tu contraseña para mayor seguridad.",
+    type: "warning",
+    read: true,
+    date: "2024-07-03T09:15:00Z",
+  },
+  {
+    id: "4",
+    title: "Error en la transacción",
+    description: "Hubo un error al procesar tu último pago.",
+    type: "error",
+    read: true,
+    date: "2024-07-04T14:45:00Z",
+  },
+];


### PR DESCRIPTION
<p align="center"> <img src="https://github.com/user-attachments/assets/25cfd5b8-e303-4af6-920e-e42d1ac8d418" alt="CLR-S (2)"> </p>

# Pull Request | GrantChain

## 1. Issue Link

<!-- Provide the link to the related issue here -->

- Closes #58 

---

## 2. Brief Description of the Issue

This PR implements the **In-App Notification System UI** as specified. The user can now click on a bell icon located beside the dark/light mode toggle to view recent notifications via a dropdown UI. This improves user awareness and notification access within the app.

---

## 3. Type of Change

Mark with an `x` all the checkboxes that apply (like `[x]`).

- [ ] 📝 Documentation (updates to README, docs, or comments)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 👌 Enhancement (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

---

## 4. Changes Made

<!-- Describe the main changes and enhancements made to address the issue. List the modifications clearly and concisely. -->


- Created a `Notification` TypeScript interface
- Added a bell icon beside the theme toggle using lucide-react with badge for unread items.
- Implemented a dropdown menu using @shadcn/ui components to display mock notifications.
- Styled the list to clearly indicate read vs. unread messages.
- Ensured responsive design and compatibility with both light and dark mode.
- Added mock data in local component state (no backend logic).

---

## 5. Evidence Before Solution

![image](https://github.com/user-attachments/assets/d069757f-7dd5-4cf4-92f3-c6caf4946a15)

---

## 6. Evidence After Solution

[Loom Video - After Solution](https://www.loom.com/share/ff76b1ddd9b94633bd2d8fa623065a6f?sid=3ee9ebcc-5336-4ea7-a906-c156e9c3512c)

---

## 7. Important Notes

<!-- Any other relevant information that reviewers should be aware of, such as potential impacts, related issues, dependencies, or additional setup instructions. -->

- Fully uses ShadCN UI components to maintain design consistency.
- Badge count on the bell auto-updates based on mock data.
- Light/dark themes supported via Tailwind theming.
- Responsive layout confirmed on mobile, tablet, and desktop.
- No backend involved—data is mocked for UI testing.

# If you don't use this template, you'd be ignored
