### PR TITLE
feat: change dark mode color

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.6",
         "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-popover": "^1.1.13",
+        "@radix-ui/react-progress": "^1.1.7",
         "@radix-ui/react-scroll-area": "^1.2.9",
         "@radix-ui/react-select": "^2.2.4",
         "@radix-ui/react-separator": "^1.1.2",
@@ -5235,6 +5236,30 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
+      "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -37,25 +37,25 @@
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
+    --background: 0 0% 0%;
+    --foreground: 0 0% 98%;
+    --card: 0 0% 3.9%;
+    --card-foreground: 0 0% 98%;
+    --popover: 0 0% 3.9%;
+    --popover-foreground: 0 0% 98%;
     --primary: 15 90% 55%;
     --primary-foreground: 0 0% 100%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
+    --secondary: 0 0% 14.9%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 0 0% 14.9%;
+    --muted-foreground: 0 0% 63.9%;
+    --accent: 0 0% 14.9%;
+    --accent-foreground: 0 0% 98%;
     --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 224.3 76.3% 94.1%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 0 0% 14.9%;
+    --input: 0 0% 14.9%;
+    --ring: 0 0% 83.1%;
   }
 }
 


### PR DESCRIPTION
Here's the pull request description following your requested format:

<p align="center">
  <img src="https://github.com/user-attachments/assets/25cfd5b8-e303-4af6-920e-e42d1ac8d418" alt="CLR-S (2)">
</p>

# Pull Request | GrantChain

## 1. Issue Link
- Closes #78 

---

## 2. Brief Description of the Issue
The dark mode theme currently uses a dark blue background (222.2 84% 4.9%) instead of true black as specified in the design system. This PR updates the dark theme to use pure black in HSL format while maintaining proper contrast and visual hierarchy.

---

## 3. Type of Change
- [x] 👌 Enhancement (non-breaking change which adds functionality)

---

## 4. Changes Made
- Updated dark theme background to pure black in HSL format (0 0% 0%)
- Adjusted card and popover backgrounds to very dark gray (0 0% 3.9%) for visual hierarchy
- Modified secondary/muted/accent colors to dark gray (0 0% 14.9%) for proper contrast
- Updated border and input colors to maintain visibility
- Adjusted foreground colors for optimal readability on black background
- Ensured all changes maintain HSL format consistency throughout the theme

---

## 5. Evidence Before Solution
<img width="1600" height="900" alt="Screenshot (94)" src="https://github.com/user-attachments/assets/cf9bd34d-1d01-4672-b16b-214bb7320ecb" />


---

## 6. Evidence After Solution
<img width="1600" height="900" alt="Screenshot (93)" src="https://github.com/user-attachments/assets/bab7938d-63dc-4923-91c2-c95cd5acd7bc" />


---

## 7. Important Notes
- All color values remain in HSL format for consistency
- Contrast ratios have been verified for accessibility
- Component hierarchy is preserved with subtle elevation differences
- No breaking changes to existing functionality
- The change aligns with ShadCN's dark theme specifications