### PR TITLE
Feat/multi language support implementation

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -7,5 +7,13 @@
     "button": {
       "learnMore": "Learn More"
     }
+  },
+  "header": {
+    "connectWallet": "Connect Wallet",
+    "disconnect": "Disconnect",
+    "wallet": "Wallet",
+    "help": "Help",
+    "reportIssue": "Report Issue",
+    "dashboard": "Dashboard"
   }
 }

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -7,5 +7,13 @@
     "button": {
       "learnMore": "Aprender más"
     }
+  },
+  "header": {
+    "connectWallet": "Conectar Billetera",
+    "disconnect": "Desconectar",
+    "wallet": "Billetera",
+    "help": "Ayuda",
+    "reportIssue": "Reportar Problema",
+    "dashboard": "Tablero"
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono, Titillium_Web } from "next/font/google";
 import "./globals.css";
 import { GlobalProvider } from "@/components/providers/global.provider";
+import { I18nProvider } from "@/components/providers/i18n.provider";
 import { Toaster } from "sonner";
 
 const geistSans = Geist({
@@ -35,7 +36,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${titilliumWeb.variable} antialiased`}
       >
-        <GlobalProvider>{children}</GlobalProvider>
+        <I18nProvider>
+          <GlobalProvider>{children}</GlobalProvider>
+        </I18nProvider>
         <Toaster />
       </body>
     </html>

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -1,13 +1,13 @@
 "use client";
 
+import { LanguageSwitcher } from "@/components/shared/LanguageSwitcher";
 import { Button } from "@/components/ui/button";
 import { useWallet } from "@/components/wallet/hooks/useWallet";
 import useLayoutDashboard from "@/hooks/useLayoutDashboard";
 import { Wallet as WalletIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { MobileTrigger } from "../sidebar/mobile-trigger";
 import { ThemeToggle } from "../sidebar/theme-toggler";
-import { useTranslation } from "react-i18next";
-import { LanguageSwitcher } from "@/components/shared/LanguageSwitcher";
 
 export const Header = () => {
   const { handleConnect, handleDisconnect, account } = useWallet();

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -6,9 +6,12 @@ import useLayoutDashboard from "@/hooks/useLayoutDashboard";
 import { Wallet as WalletIcon } from "lucide-react";
 import { MobileTrigger } from "../sidebar/mobile-trigger";
 import { ThemeToggle } from "../sidebar/theme-toggler";
+import { useTranslation } from "react-i18next";
+import { LanguageSwitcher } from "@/components/shared/LanguageSwitcher";
 
 export const Header = () => {
   const { handleConnect, handleDisconnect, account } = useWallet();
+  const { t } = useTranslation();
   const isConnected = Boolean(account);
   const { label } = useLayoutDashboard();
 
@@ -19,13 +22,14 @@ export const Header = () => {
 
         {label !== "Help" && label !== "Report Issue" && (
           <h2 className="text-xl md:text-2xl font-bold tracking-tight">
-            {label}
+            {t(`header.${label.replace(/\s+/g, "").toLowerCase()}`, label)}
           </h2>
         )}
 
         <div className="flex items-center gap-4">
           {/* <NotificationButton /> */}
           <ThemeToggle />
+          <LanguageSwitcher />
           <Button
             variant="outline"
             size="default"
@@ -33,7 +37,7 @@ export const Header = () => {
             className="flex items-center gap-2"
           >
             <WalletIcon className="h-4 w-4" />
-            {isConnected ? "Disconnect" : "Connect Wallet"}
+            {isConnected ? t("header.disconnect") : t("header.connectWallet")}
           </Button>
         </div>
       </div>

--- a/src/components/providers/i18n.provider.tsx
+++ b/src/components/providers/i18n.provider.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { ReactNode, useEffect, useState } from "react";
+import { I18nextProvider } from "react-i18next";
+import i18n from "@/i18n/config";
+
+const LANG_STORAGE_KEY = "app_language";
+
+interface I18nProviderProps {
+  children: ReactNode;
+}
+
+export const I18nProvider = ({ children }: I18nProviderProps) => {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const persisted =
+      typeof window !== "undefined" ? localStorage.getItem(LANG_STORAGE_KEY) : null;
+    if (persisted && i18n.language !== persisted) {
+      i18n.changeLanguage(persisted).finally(() => setReady(true));
+    } else {
+      setReady(true);
+    }
+  }, []);
+
+  if (!ready) return null; // could add a small skeleton if needed
+
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
+};
+
+export const persistLanguage = (lng: string) => {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(LANG_STORAGE_KEY, lng);
+};

--- a/src/components/providers/i18n.provider.tsx
+++ b/src/components/providers/i18n.provider.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { ReactNode, useEffect, useState } from "react";
-import { I18nextProvider } from "react-i18next";
 import i18n from "@/i18n/config";
+import { type ReactNode, useEffect, useState } from "react";
+import { I18nextProvider } from "react-i18next";
 
 const LANG_STORAGE_KEY = "app_language";
 
@@ -15,7 +15,9 @@ export const I18nProvider = ({ children }: I18nProviderProps) => {
 
   useEffect(() => {
     const persisted =
-      typeof window !== "undefined" ? localStorage.getItem(LANG_STORAGE_KEY) : null;
+      typeof window !== "undefined"
+        ? localStorage.getItem(LANG_STORAGE_KEY)
+        : null;
     if (persisted && i18n.language !== persisted) {
       i18n.changeLanguage(persisted).finally(() => setReady(true));
     } else {

--- a/src/components/shared/LanguageSwitcher.tsx
+++ b/src/components/shared/LanguageSwitcher.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useTranslation } from "react-i18next";
+import { persistLanguage } from "@/components/providers/i18n.provider";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -10,7 +9,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Globe } from "lucide-react";
-import { persistLanguage } from "@/components/providers/i18n.provider";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 type LanguageOption = {
   code: string;

--- a/src/components/shared/LanguageSwitcher.tsx
+++ b/src/components/shared/LanguageSwitcher.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Globe } from "lucide-react";
+import { persistLanguage } from "@/components/providers/i18n.provider";
+
+type LanguageOption = {
+  code: string;
+  label: string;
+  flag: string;
+};
+
+const LANGS: LanguageOption[] = [
+  { code: "en", label: "EN", flag: "🇺🇸" },
+  { code: "es", label: "ES", flag: "🇪🇸" },
+];
+
+export const LanguageSwitcher = () => {
+  const { i18n } = useTranslation();
+  const [current, setCurrent] = useState(i18n.language || "en");
+
+  useEffect(() => {
+    setCurrent(i18n.language);
+  }, [i18n.language]);
+
+  const handleChange = async (lng: string) => {
+    if (lng === current) return;
+    await i18n.changeLanguage(lng);
+    persistLanguage(lng);
+    setCurrent(lng);
+  };
+
+  const active = LANGS.find((l) => current.startsWith(l.code)) || LANGS[0];
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          aria-label="Change language"
+          className="relative"
+        >
+          <Globe className="h-4 w-4" />
+          <span className="sr-only">Language</span>
+          <span className="absolute -bottom-1 -right-1 text-[10px] font-semibold">
+            {active.label}
+          </span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-32">
+        {LANGS.map((lang) => (
+          <DropdownMenuItem
+            key={lang.code}
+            onClick={() => handleChange(lang.code)}
+            className={
+              lang.code === active.code ? "font-semibold" : "font-normal"
+            }
+            data-testid={`lang-${lang.code}`}
+          >
+            <span className="mr-2" role="img" aria-label={lang.label}>
+              {lang.flag}
+            </span>
+            {lang.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -3,6 +3,8 @@ import LanguageDetector from "i18next-browser-languagedetector";
 import Backend from "i18next-http-backend";
 import { initReactI18next } from "react-i18next";
 
+// NOTE: We store one JSON per language at /public/locales/{lng}.json (no namespace folders)
+// Adjust backend loadPath accordingly so keys like "header.disconnect" resolve properly.
 i18n
   .use(Backend)
   .use(LanguageDetector)
@@ -10,6 +12,8 @@ i18n
   .init({
     fallbackLng: "en",
     debug: process.env.NODE_ENV === "development",
+    defaultNS: "translation",
+    ns: ["translation"],
     detection: {
       order: [
         "querystring",
@@ -21,13 +25,17 @@ i18n
         "path",
         "subdomain",
       ],
-      caches: ["cookie"],
+      caches: ["cookie", "localStorage"],
+      cookieMinutes: 60 * 24 * 365, // one year
     },
     interpolation: {
       escapeValue: false,
     },
     backend: {
-      loadPath: "/locales/{{lng}}/{{ns}}.json",
+      loadPath: "/locales/{{lng}}.json",
+    },
+    react: {
+      useSuspense: false,
     },
   });
 


### PR DESCRIPTION
# Pull Request | GrantChain

## 1. Issue Link
- Closes #130 

---

## 2. Brief Description of the Issue
Implemented the base for multilingual support (EN/ES) in the application: proper i18next initialization, global provider, language detection and persistence, and the first translated module (Header + wallet actions).  
Previously, translations did not load because `loadPath` did not match the actual structure, and language changes did not update the UI.

---

## 3. Type of Change
- [x] 📚 Documentation (updates to README, docs, or comments)  
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)  
- [x] ✨ Enhancement (non-breaking change which adds functionality)  
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)  

---

## 4. Changes Made
- Adjusted i18next configuration: fixed `loadPath` to `/locales/{{lng}}.json`, simplified namespaces, and ensured fallback.  
- Created `I18nProvider` with loading of persisted language (localStorage/cookie) and initial block until ready.  
- Added `LanguageSwitcher` (dropdown with EN/ES, flags, persistence, and instant updates).  
- Integrated provider in `layout.tsx` before `GlobalProvider`.  
- Updated files `en.json` and `es.json` with new keys (`header.*`, `reusable.*`, `header.dashboard`).  
- Updated Header: used `t` for connect/disconnect button and dynamic title (fallback to original label).  
- Language persistence and detection improved (query, cookie, localStorage, browser, etc.).  
- Added base keys for future expansions (dashboard, etc.).  

---

## 5. Important Notes
- Pending translation: authentication forms, payouts, support, validations, and error messages (zod/error map).  
- Current structure: single JSON per language (no separated namespaces); scalable by adding sections (`auth`, `payouts`, `support`, `validation`, `common`).  
- Manual validation: language change reflects wallet + title instantly; persistence after refresh.  
- No breaking changes: if translation fails, fallback is English.  
- Next milestone: translate authentication, extract form texts before adding dependent features.  
- Performance: slight overhead; consider splitting JSON if it grows too large.  
- Suggested tests (not included): snapshot of header in two languages, persistence test (simulate localStorage), fallback verification.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a language switcher in the header with English and Spanish options; your selection is remembered.
  - Localized header labels, including Connect Wallet, Disconnect, Wallet, Help, Report Issue, and Dashboard.

- Refactor
  - Updated app initialization to ensure consistent translation loading across the app.

- Chores
  - Added new English and Spanish locale entries for header-related text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->